### PR TITLE
Add limit option to findTags

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Get all tags matching the tag specified from the tags file at the path.
     (default: `false`)
   * `partialMatch` - `true` to include tags that partially match the given tag
     (default: `false`)
+  * `limit` - maximum number of matches to return. Should be a positive integer.
+    (default: unlimited)
 
 * `callback` - The function to call when complete with an error as the first
              argument and an array containing objects that have `name` and

--- a/spec/ctags-spec.coffee
+++ b/spec/ctags-spec.coffee
@@ -80,6 +80,25 @@ describe 'ctags', ->
           expect(tags[0].kind).toBe 'f'
           expect(tags[0].lineNumber).toBe 0
 
+    describe 'when limit is set', ->
+      it 'returns the correct number of tags', ->
+        callback = jasmine.createSpy('callback')
+        tags = ctags.findTags(tagsFile, 'dup', {partialMatch: true, limit: 1}, callback)
+
+        waitsFor ->
+          callback.callCount is 1
+
+        runs ->
+          expect(callback.argsForCall[0][0]).toBeFalsy()
+          tags = callback.argsForCall[0][1]
+
+          expect(tags.length).toBe 1
+          expect(tags[0].name).toBe 'duplicate'
+
+      it 'throws for invalid values', ->
+        expect(() -> ctags.findTags(tagsFile, '', limit: 'test')).toThrow()
+        expect(() -> ctags.findTags(tagsFile, '', limit: 0)).toThrow()
+
   describe '.createReadStream(tagsFilePath)', ->
     it 'returns a stream that emits data and end events', ->
       stream = ctags.createReadStream(tagsFile)

--- a/src/ctags.coffee
+++ b/src/ctags.coffee
@@ -12,10 +12,12 @@ exports.findTags = (tagsFilePath, tag, options, callback) ->
     callback = options
     options = null
 
-  {partialMatch, caseInsensitive} = options ? {}
+  {partialMatch, caseInsensitive, limit} = options ? {}
+  if limit? and (not Number.isInteger(limit) or limit <= 0)
+    throw new TypeError('limit must be a positive integer')
 
   tagsWrapper = new Tags(tagsFilePath)
-  tagsWrapper.findTags tag, partialMatch, caseInsensitive, (error, tags) ->
+  tagsWrapper.findTags tag, partialMatch, caseInsensitive, limit, (error, tags) ->
     tagsWrapper.end()
     callback?(error, tags)
 

--- a/src/tag-finder.cc
+++ b/src/tag-finder.cc
@@ -4,7 +4,8 @@ void TagFinder::Execute() {
   tagEntry entry;
   if (tagsFind(file, &entry, tag.data(), options) == TagSuccess) {
     matches.push_back(Tag(entry));
-    while (tagsFindNext(file, &entry) == TagSuccess)
+    while ((limit == 0 || matches.size() < limit) &&
+           tagsFindNext(file, &entry) == TagSuccess)
       matches.push_back(Tag(entry));
   }
 }

--- a/src/tag-finder.h
+++ b/src/tag-finder.h
@@ -11,8 +11,16 @@ using namespace v8;
 
 class TagFinder : public Nan::AsyncWorker {
  public:
-  TagFinder(Nan::Callback *callback, std::string tag, int options, tagFile *file)
-    : Nan::AsyncWorker(callback), options(options), tag(tag), file(file) {}
+  TagFinder(Nan::Callback* callback,
+            std::string tag,
+            int options,
+            size_t limit,
+            tagFile* file)
+      : Nan::AsyncWorker(callback),
+        options(options),
+        limit(limit),
+        tag(tag),
+        file(file) {}
 
   ~TagFinder() {}
 
@@ -21,6 +29,7 @@ class TagFinder : public Nan::AsyncWorker {
 
  private:
   int options;
+  size_t limit;
   std::string tag;
   std::vector< Tag > matches;
   tagFile *file;

--- a/src/tags.cc
+++ b/src/tags.cc
@@ -56,8 +56,9 @@ NAN_METHOD(Tags::FindTags) {
   else
     options |= TAG_OBSERVECASE;
 
-  Nan::Callback *callback = new Nan::Callback(info[3].As<Function>());
-  Nan::AsyncQueueWorker(new TagFinder(callback, tag, options, tagFile));
+  size_t limit = info[3]->IntegerValue();
+  Nan::Callback *callback = new Nan::Callback(info[4].As<Function>());
+  Nan::AsyncQueueWorker(new TagFinder(callback, tag, options, limit, tagFile));
   info.GetReturnValue().SetUndefined();
 }
 


### PR DESCRIPTION
This adds an optional `limit` option to `findTags` which allows the user to specify the maximum number of results returned. This saves a lot of computation with large tag files.

Detailed semantics:
- if `limit` is undefined or null, it is ignored (unlimited results)
- otherwise, `limit` must be a positive integer, strictly enforced at runtime