### PR TITLE
Fixes node 12 compilation errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 os:
   - linux
-  - osx
   
 sudo: false
 
@@ -19,10 +18,7 @@ install:
 language: node_js
 
 node_js:
-  - "6"
-  - "8"
-  - "10"
-  - "12"
+  - "node"
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,7 @@ install:
 language: node_js
 
 node_js:
-  - "iojs"
-  - "node"
-  - "0.10"
-  - "0.12"
+  - "12.13.1"
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 os:
   - linux
+  - osx
+  
 sudo: false
 
 addons:
@@ -17,7 +19,10 @@ install:
 language: node_js
 
 node_js:
-  - "12.13.1"
+  - "6"
+  - "8"
+  - "10"
+  - "12"
 
 notifications:
   email:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1031 @@
+{
+  "name": "ctags",
+  "version": "3.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "dev": true
+    },
+    "ansi": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
+      "integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+      "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=",
+      "dev": true
+    },
+    "argparse": {
+      "version": "0.1.16",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+      "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
+      "dev": true,
+      "requires": {
+        "underscore": "~1.7.0",
+        "underscore.string": "~2.4.0"
+      },
+      "dependencies": {
+        "underscore.string": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+          "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs=",
+          "dev": true
+        }
+      }
+    },
+    "async": {
+      "version": "0.1.22",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
+      "integrity": "sha1-D8GqoIig4+8Ovi2IMbqw3PiEUGE=",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "block-stream": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+      "dev": true,
+      "requires": {
+        "inherits": "~2.0.0"
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "chalk": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+      "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "~1.0.0",
+        "has-color": "~0.1.0",
+        "strip-ansi": "~0.1.0"
+      }
+    },
+    "coffee-script": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
+      "integrity": "sha1-FQ1rTLUiiUNp7+1qIQHCC8f0pPQ=",
+      "dev": true
+    },
+    "coffeelint": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/coffeelint/-/coffeelint-0.5.7.tgz",
+      "integrity": "sha1-PRJc3emV1kHL2ECwrFNsXN9vaNs=",
+      "dev": true,
+      "requires": {
+        "coffee-script": ">=1.6.0",
+        "glob": ">=3.1.9",
+        "optimist": ">=0.2.8"
+      },
+      "dependencies": {
+        "coffee-script": {
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.6.2.tgz",
+          "integrity": "sha1-/ZyINpweQeMwegoWDXE/IlE8k7M=",
+          "dev": true
+        },
+        "glob": {
+          "version": "3.1.14",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.14.tgz",
+          "integrity": "sha1-+XpzHEHaZpXcg5RLuyF36aKbNj0=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "~1.1.2",
+            "inherits": "1",
+            "minimatch": "0.2"
+          },
+          "dependencies": {
+            "graceful-fs": {
+              "version": "1.1.14",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.1.14.tgz",
+              "integrity": "sha1-BweNtfY3f2Mh/Oqu30l94STclGU=",
+              "dev": true
+            },
+            "inherits": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz",
+              "integrity": "sha1-OOGXUoW/H3upyE2hArsSdxMirEg=",
+              "dev": true
+            },
+            "minimatch": {
+              "version": "0.2.9",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.9.tgz",
+              "integrity": "sha1-uAr5R+aoOoxo8m5UwNYSW6yfiH8=",
+              "dev": true,
+              "requires": {
+                "lru-cache": "~2.0.0",
+                "sigmund": "~1.0.0"
+              },
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.0.4",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.0.4.tgz",
+                  "integrity": "sha1-uLYa4JhIOF7Gdodg45wSPn45Voo=",
+                  "dev": true
+                },
+                "sigmund": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+                  "integrity": "sha1-ZqKzp0mui1+4nv1PzAHclPvgIpY=",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "optimist": {
+          "version": "0.3.5",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.5.tgz",
+          "integrity": "sha1-A2VLUkFwMDEtEJ85sVmCW2AwkwQ=",
+          "dev": true,
+          "requires": {
+            "wordwrap": "~0.0.2"
+          },
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.2",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+              "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+              "dev": true
+            }
+          }
+        },
+        "vows": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/vows/-/vows-0.7.0.tgz",
+          "integrity": "sha1-3QBl8RC6DAptY+hEhRwyCBdtWGc=",
+          "requires": {
+            "diff": "~1.0.3",
+            "eyes": ">=0.1.6"
+          },
+          "dependencies": {
+            "diff": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.4.tgz",
+              "integrity": "sha1-+P4oT7rB1lHUGxHTzqkT/ZOM2RU="
+            },
+            "eyes": {
+              "version": "0.1.8",
+              "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+              "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
+            }
+          }
+        }
+      }
+    },
+    "coffeestack": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/coffeestack/-/coffeestack-1.2.0.tgz",
+      "integrity": "sha512-vXT7ZxSZ4lXHh/0A2cODyFqrVIl4Vb0Er5wcS2SrFN4jW8g1qIAmcMsRlRdUKvnvfmKixvENYspAyF/ihWbpyw==",
+      "dev": true,
+      "requires": {
+        "coffee-script": "~1.8.0",
+        "fs-plus": "^3.1.1",
+        "source-map": "~0.1.43"
+      },
+      "dependencies": {
+        "coffee-script": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.8.0.tgz",
+          "integrity": "sha1-nJ8dK0pSoADe0Vtll5FwNkgmPB0=",
+          "dev": true,
+          "requires": {
+            "mkdirp": "~0.3.5"
+          }
+        }
+      }
+    },
+    "colors": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+      "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
+      "dev": true
+    },
+    "commander": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-1.1.1.tgz",
+      "integrity": "sha1-UNFlGGiuYOzP8KLZ80WVN2vGsEE=",
+      "dev": true,
+      "requires": {
+        "keypress": "0.1.x"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "dateformat": {
+      "version": "1.0.2-1.2.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
+      "integrity": "sha1-sCIMAt6YYXQztyhRz0fePfLNvuk=",
+      "dev": true
+    },
+    "duplexer": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
+    },
+    "esprima": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+      "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=",
+      "dev": true
+    },
+    "event-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.1.7.tgz",
+      "integrity": "sha1-tMVAAS0P4UmEIPPYlGAI22OTw3o=",
+      "requires": {
+        "duplexer": "~0.1.1",
+        "from": "~0",
+        "map-stream": "~0.1.0",
+        "pause-stream": "0.0.11",
+        "split": "0.2",
+        "stream-combiner": "~0.0.4",
+        "through": "~2.3.1"
+      }
+    },
+    "eventemitter2": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+      "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
+      "dev": true
+    },
+    "exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true
+    },
+    "fileset": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.1.8.tgz",
+      "integrity": "sha1-UGuRqTluqn4y+0KoQHfHoMc2t0E=",
+      "dev": true,
+      "requires": {
+        "glob": "3.x",
+        "minimatch": "0.x"
+      }
+    },
+    "findup-sync": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+      "integrity": "sha1-fz56l7gjksZTvwZYm9hRkOk8NoM=",
+      "dev": true,
+      "requires": {
+        "glob": "~3.2.9",
+        "lodash": "~2.4.1"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "3.2.11",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+          "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+          "dev": true,
+          "requires": {
+            "inherits": "2",
+            "minimatch": "0.3"
+          }
+        },
+        "lodash": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+          "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "2",
+            "sigmund": "~1.0.0"
+          }
+        }
+      }
+    },
+    "from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
+    },
+    "fs-plus": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fs-plus/-/fs-plus-3.1.1.tgz",
+      "integrity": "sha512-Se2PJdOWXqos1qVTkvqqjb0CSnfBnwwD+pq+z4ksT+e97mEShod/hrNg0TRCCsXPbJzcIq+NuzQhigunMWMJUA==",
+      "dev": true,
+      "requires": {
+        "async": "^1.5.2",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.2",
+        "underscore-plus": "1.x"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "fstream": {
+      "version": "0.1.31",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
+      "integrity": "sha1-czfwWPu7vvqMn1YaKMqwhJICyYg=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "~3.0.2",
+        "inherits": "~2.0.0",
+        "mkdirp": "0.5",
+        "rimraf": "2"
+      },
+      "dependencies": {
+        "graceful-fs": {
+          "version": "3.0.12",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.12.tgz",
+          "integrity": "sha512-J55gaCS4iTTJfTXIxSVw3EMQckcqkpdRv3IR7gu6sq0+tbC363Zx6KH/SEwXASK9JRbhyZmVjJEVJIOxYsB3Qg==",
+          "dev": true,
+          "requires": {
+            "natives": "^1.1.3"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        }
+      }
+    },
+    "gaze": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.3.4.tgz",
+      "integrity": "sha1-X5S92gr+U7xxCWm81vKCVI1gwnk=",
+      "dev": true,
+      "requires": {
+        "fileset": "~0.1.5",
+        "minimatch": "~0.2.9"
+      }
+    },
+    "getobject": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
+      "integrity": "sha1-BHpEl4n6Fg0Bj1SG7ZEyC27HiFw=",
+      "dev": true
+    },
+    "glob": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+      "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "~1.2.0",
+        "inherits": "1",
+        "minimatch": "~0.2.11"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
+          "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
+          "dev": true
+        }
+      }
+    },
+    "graceful-fs": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+      "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
+      "dev": true
+    },
+    "grunt": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
+      "integrity": "sha1-VpN81RlDJK3/bSB2MYMqnWuk5/A=",
+      "dev": true,
+      "requires": {
+        "async": "~0.1.22",
+        "coffee-script": "~1.3.3",
+        "colors": "~0.6.2",
+        "dateformat": "1.0.2-1.2.3",
+        "eventemitter2": "~0.4.13",
+        "exit": "~0.1.1",
+        "findup-sync": "~0.1.2",
+        "getobject": "~0.1.0",
+        "glob": "~3.1.21",
+        "grunt-legacy-log": "~0.1.0",
+        "grunt-legacy-util": "~0.2.0",
+        "hooker": "~0.2.3",
+        "iconv-lite": "~0.2.11",
+        "js-yaml": "~2.0.5",
+        "lodash": "~0.9.2",
+        "minimatch": "~0.2.12",
+        "nopt": "~1.0.10",
+        "rimraf": "~2.2.8",
+        "underscore.string": "~2.2.1",
+        "which": "~1.0.5"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.2.8",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+          "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
+          "dev": true
+        }
+      }
+    },
+    "grunt-cli": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-0.1.13.tgz",
+      "integrity": "sha1-6evEBHYx9QEtkidww5N4EzytEPQ=",
+      "dev": true,
+      "requires": {
+        "findup-sync": "~0.1.0",
+        "nopt": "~1.0.10",
+        "resolve": "~0.3.1"
+      }
+    },
+    "grunt-coffeelint": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/grunt-coffeelint/-/grunt-coffeelint-0.0.6.tgz",
+      "integrity": "sha1-/NMBr9Z3XUGYCwDQHKYzG8kDBsw=",
+      "dev": true,
+      "requires": {
+        "coffeelint": "~0.5"
+      }
+    },
+    "grunt-contrib-coffee": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-coffee/-/grunt-contrib-coffee-0.9.0.tgz",
+      "integrity": "sha1-UZr1EF2hL+MWO7UOHKeAtslT77A=",
+      "dev": true,
+      "requires": {
+        "chalk": "~0.4.0",
+        "coffee-script": "~1.7.0",
+        "lodash": "~2.4.1"
+      },
+      "dependencies": {
+        "coffee-script": {
+          "version": "1.7.1",
+          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.7.1.tgz",
+          "integrity": "sha1-YplqhheAx15tUGnROCJyO3NAS/w=",
+          "dev": true,
+          "requires": {
+            "mkdirp": "~0.3.5"
+          }
+        },
+        "lodash": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+          "dev": true
+        }
+      }
+    },
+    "grunt-legacy-log": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz",
+      "integrity": "sha1-7ClCboAwIa9ZAp+H0vnNczWgVTE=",
+      "dev": true,
+      "requires": {
+        "colors": "~0.6.2",
+        "grunt-legacy-log-utils": "~0.1.1",
+        "hooker": "~0.2.3",
+        "lodash": "~2.4.1",
+        "underscore.string": "~2.3.3"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+          "dev": true
+        },
+        "underscore.string": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+          "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
+          "dev": true
+        }
+      }
+    },
+    "grunt-legacy-log-utils": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz",
+      "integrity": "sha1-wHBrndkGThFvNvI/5OawSGcsD34=",
+      "dev": true,
+      "requires": {
+        "colors": "~0.6.2",
+        "lodash": "~2.4.1",
+        "underscore.string": "~2.3.3"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+          "dev": true
+        },
+        "underscore.string": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+          "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
+          "dev": true
+        }
+      }
+    },
+    "grunt-legacy-util": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
+      "integrity": "sha1-kzJIhNv343qf98Am3/RR2UqeVUs=",
+      "dev": true,
+      "requires": {
+        "async": "~0.1.22",
+        "exit": "~0.1.1",
+        "getobject": "~0.1.0",
+        "hooker": "~0.2.3",
+        "lodash": "~0.9.2",
+        "underscore.string": "~2.2.1",
+        "which": "~1.0.5"
+      }
+    },
+    "grunt-shell": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/grunt-shell/-/grunt-shell-0.2.2.tgz",
+      "integrity": "sha1-f9470zu9SghxY428SGc4n3/ZX+Y=",
+      "dev": true
+    },
+    "has-color": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+      "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
+      "dev": true
+    },
+    "hooker": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+      "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk=",
+      "dev": true
+    },
+    "iconv-lite": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
+      "integrity": "sha1-HOYKOleGSiktEyH/RgnKS7llrcg=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "jasmine-focused": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/jasmine-focused/-/jasmine-focused-1.0.7.tgz",
+      "integrity": "sha1-uDx1fIAOaOHW78GjoaE/85/23NI=",
+      "dev": true,
+      "requires": {
+        "jasmine-node": "git+https://github.com/kevinsawicki/jasmine-node.git#81af4f953a2b7dfb5bde8331c05362a4b464c5ef",
+        "underscore-plus": "1.x",
+        "walkdir": "0.0.7"
+      }
+    },
+    "jasmine-node": {
+      "version": "git+https://github.com/kevinsawicki/jasmine-node.git#81af4f953a2b7dfb5bde8331c05362a4b464c5ef",
+      "from": "git+https://github.com/kevinsawicki/jasmine-node.git#81af4f953a2b7dfb5bde8331c05362a4b464c5ef",
+      "dev": true,
+      "requires": {
+        "coffee-script": ">=1.0.1",
+        "coffeestack": ">=1 <2",
+        "gaze": "~0.3.2",
+        "jasmine-reporters": ">=0.2.0",
+        "mkdirp": "~0.3.5",
+        "requirejs": ">=0.27.1",
+        "underscore": ">= 1.3.1",
+        "walkdir": ">= 0.0.1"
+      }
+    },
+    "jasmine-reporters": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/jasmine-reporters/-/jasmine-reporters-2.3.2.tgz",
+      "integrity": "sha512-u/7AT9SkuZsUfFBLLzbErohTGNsEUCKaQbsVYnLFW1gEuL2DzmBL4n8v90uZsqIqlWvWUgian8J6yOt5Fyk/+A==",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1",
+        "xmldom": "^0.1.22"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        }
+      }
+    },
+    "js-yaml": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
+      "integrity": "sha1-olrmUJmZ6X3yeMZxnaEb0Gh3Q6g=",
+      "dev": true,
+      "requires": {
+        "argparse": "~ 0.1.11",
+        "esprima": "~ 1.0.2"
+      }
+    },
+    "keypress": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz",
+      "integrity": "sha1-SjGI1CkbZrT2XtuZ+AaqmuKTWSo=",
+      "dev": true
+    },
+    "lodash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
+      "integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw=",
+      "dev": true
+    },
+    "lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+      "dev": true
+    },
+    "map-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+      "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ="
+    },
+    "minimatch": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+      "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+      "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc=",
+      "dev": true
+    },
+    "nan": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+    },
+    "natives": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.6.tgz",
+      "integrity": "sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==",
+      "dev": true
+    },
+    "node-cpplint": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/node-cpplint/-/node-cpplint-0.1.5.tgz",
+      "integrity": "sha1-2YDMU45KufUKmsfh6kgBwa/VkeI=",
+      "dev": true,
+      "requires": {
+        "colors": "~0.6.0-1",
+        "commander": "~1.1.1"
+      }
+    },
+    "node-gyp": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-0.8.5.tgz",
+      "integrity": "sha1-dB5KVRQxhkjkf8hELZva1m/bH4Q=",
+      "dev": true,
+      "requires": {
+        "fstream": "~0.1.13",
+        "glob": "3",
+        "graceful-fs": "1",
+        "minimatch": "0.2",
+        "mkdirp": "0.3",
+        "nopt": "2",
+        "npmlog": "0",
+        "osenv": "0",
+        "request": "2.9",
+        "rimraf": "2",
+        "semver": "1",
+        "tar": "~0.1.12",
+        "which": "1"
+      },
+      "dependencies": {
+        "nopt": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
+          "integrity": "sha1-KqCbfRdoSHs7ianFqlIzW/8Lrqc=",
+          "dev": true,
+          "requires": {
+            "abbrev": "1"
+          }
+        }
+      }
+    },
+    "nopt": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+      "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+      "dev": true,
+      "requires": {
+        "abbrev": "1"
+      }
+    },
+    "npmlog": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-0.1.1.tgz",
+      "integrity": "sha1-i5ueRAXX7EjDHCNGllqtx6uuyqU=",
+      "dev": true,
+      "requires": {
+        "ansi": "~0.3.0"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "osenv": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+      "dev": true,
+      "requires": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+      "requires": {
+        "through": "~2.3"
+      }
+    },
+    "request": {
+      "version": "2.9.203",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.9.203.tgz",
+      "integrity": "sha1-bBcRpUB/uUoRQhlWPkQUW8v0cjo=",
+      "dev": true
+    },
+    "requirejs": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.6.tgz",
+      "integrity": "sha512-ipEzlWQe6RK3jkzikgCupiTbTvm4S0/CAU5GlgptkN5SO6F3u0UD0K18wy6ErDqiCyP4J4YYe1HuAShvsxePLg==",
+      "dev": true
+    },
+    "resolve": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz",
+      "integrity": "sha1-NMY0R8ZkxwWY0cmxJvxDsqJDEKQ=",
+      "dev": true
+    },
+    "rimraf": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.1.4.tgz",
+      "integrity": "sha1-Wm62Lu2gaPUe3lDymz5c0i89m7I=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "~1"
+      }
+    },
+    "semver": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-1.1.4.tgz",
+      "integrity": "sha1-LlpOcrqwNHLMl/cnU7RQiRLvVUA=",
+      "dev": true
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+      "dev": true
+    },
+    "source-map": {
+      "version": "0.1.43",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+      "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+      "dev": true,
+      "requires": {
+        "amdefine": ">=0.0.4"
+      }
+    },
+    "split": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/split/-/split-0.2.10.tgz",
+      "integrity": "sha1-Zwl8YB1pfOE2j0GPBs0gHPBSGlc=",
+      "requires": {
+        "through": "2"
+      }
+    },
+    "stream-combiner": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+      "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+      "requires": {
+        "duplexer": "~0.1.1"
+      }
+    },
+    "strip-ansi": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+      "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
+      "dev": true
+    },
+    "tar": {
+      "version": "0.1.20",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-0.1.20.tgz",
+      "integrity": "sha1-QpQLrltfIsdEg2mRJvnz8nRJyxM=",
+      "dev": true,
+      "requires": {
+        "block-stream": "*",
+        "fstream": "~0.1.28",
+        "inherits": "2"
+      }
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+    },
+    "underscore": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+      "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
+      "dev": true
+    },
+    "underscore-plus": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/underscore-plus/-/underscore-plus-1.7.0.tgz",
+      "integrity": "sha512-A3BEzkeicFLnr+U/Q3EyWwJAQPbA19mtZZ4h+lLq3ttm9kn8WC4R3YpuJZEXmWdLjYP47Zc8aLZm9kwdv+zzvA==",
+      "dev": true,
+      "requires": {
+        "underscore": "^1.9.1"
+      },
+      "dependencies": {
+        "underscore": {
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+          "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==",
+          "dev": true
+        }
+      }
+    },
+    "underscore.string": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
+      "integrity": "sha1-18D6KvXVoaZ/QlPa7pgTLnM/Dxk=",
+      "dev": true
+    },
+    "walkdir": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.7.tgz",
+      "integrity": "sha1-BNoCcKh6d4VAFzzb8KLbSZqNnik=",
+      "dev": true
+    },
+    "which": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
+      "integrity": "sha1-RgwdoPgQED0DIam2M6+eV15kSG8=",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "xmldom": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
+      "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "node-cpplint": "0.1.5"
   },
   "dependencies": {
-    "nan": "^2",
+    "nan": "^2.14.0",
     "event-stream": "~3.1.0"
   },
   "scripts": {

--- a/src/tag-finder.cc
+++ b/src/tag-finder.cc
@@ -15,19 +15,19 @@ void TagFinder::HandleOKCallback() {
   Local<Array> array = Nan::New<Array>(matches.size());
   for (size_t i = 0; i < matches.size(); i++) {
     Local<Object> tagObject = Nan::New<Object>();
-    tagObject->Set(Nan::New<String>("name").ToLocalChecked(),
+    Nan::Set(tagObject, Nan::New<String>("name").ToLocalChecked(),
                    Nan::New<String>(matches[i].name.data()).ToLocalChecked());
-    tagObject->Set(Nan::New<String>("file").ToLocalChecked(),
+    Nan::Set(tagObject, Nan::New<String>("file").ToLocalChecked(),
                    Nan::New<String>(matches[i].file.data()).ToLocalChecked());
-    tagObject->Set(Nan::New<String>("kind").ToLocalChecked(),
+    Nan::Set(tagObject, Nan::New<String>("kind").ToLocalChecked(),
                    Nan::New<String>(matches[i].kind.data()).ToLocalChecked());
-    tagObject->Set(Nan::New<String>("lineNumber").ToLocalChecked(),
+    Nan::Set(tagObject, Nan::New<String>("lineNumber").ToLocalChecked(),
                    Nan::New<Integer>((int32_t)matches[i].lineNumber));
     if (matches[i].pattern.length() > 0)
-      tagObject->Set(
+      Nan::Set(tagObject,
           Nan::New<String>("pattern").ToLocalChecked(),
           Nan::New<String>(matches[i].pattern.data()).ToLocalChecked());
-    array->Set(i, tagObject);
+    Nan::Set(array, i, tagObject);
   }
 
   Local<Value> argv[] = { Nan::Null(), array };

--- a/src/tag-finder.cc
+++ b/src/tag-finder.cc
@@ -31,5 +31,5 @@ void TagFinder::HandleOKCallback() {
   }
 
   Local<Value> argv[] = { Nan::Null(), array };
-  callback->Call(2, argv);
+  callback->Call(2, argv, async_resource);
 }

--- a/src/tag-reader.cc
+++ b/src/tag-reader.cc
@@ -37,5 +37,5 @@ void TagReader::HandleOKCallback() {
   }
 
   Local<Value> argv[] = { Nan::Null(), array };
-  callback->Call(2, argv);
+  callback->Call(2, argv, async_resource);
 }

--- a/src/tag-reader.cc
+++ b/src/tag-reader.cc
@@ -18,22 +18,22 @@ void TagReader::HandleOKCallback() {
   Local<Array> array = Nan::New<Array>(tags.size());
   for (size_t i = 0; i < tags.size(); i++) {
     Local<Object> tagObject = Nan::New<Object>();
-    tagObject->Set(
+    Nan::Set(tagObject,
         Nan::New<String>("name").ToLocalChecked(),
         Nan::New<String>(tags[i].name.data()).ToLocalChecked());
-    tagObject->Set(
+    Nan::Set(tagObject,
         Nan::New<String>("file").ToLocalChecked(),
         Nan::New<String>(tags[i].file.data()).ToLocalChecked());
-    tagObject->Set(
+    Nan::Set(tagObject,
         Nan::New<String>("kind").ToLocalChecked(),
         Nan::New<String>(tags[i].kind.data()).ToLocalChecked());
-    tagObject->Set(Nan::New<String>("lineNumber").ToLocalChecked(),
+    Nan::Set(tagObject, Nan::New<String>("lineNumber").ToLocalChecked(),
                    Nan::New<Integer>((int32_t)tags[i].lineNumber));
     if (tags[i].pattern.length() > 0)
-      tagObject->Set(
+      Nan::Set(tagObject,
           Nan::New<String>("pattern").ToLocalChecked(),
           Nan::New<String>(tags[i].pattern.data()).ToLocalChecked());
-    array->Set(i, tagObject);
+      Nan::Set(array, i, tagObject);
   }
 
   Local<Value> argv[] = { Nan::Null(), array };

--- a/src/tags.cc
+++ b/src/tags.cc
@@ -17,7 +17,7 @@ void Tags::Init(Local<Object> target) {
   Nan::SetMethod(proto, "findTags", Tags::FindTags);
   Nan::SetMethod(proto, "getTags", Tags::GetTags);
 
-  target->Set(Nan::New<String>("Tags").ToLocalChecked(),
+  Nan::Set(target, Nan::New<String>("Tags").ToLocalChecked(),
               newTemplate->GetFunction(context).ToLocalChecked());
 }
 

--- a/src/tags.cc
+++ b/src/tags.cc
@@ -3,8 +3,9 @@
 #include "tag-finder.h"
 #include "tag-reader.h"
 
-void Tags::Init(Handle<Object> target) {
+void Tags::Init(Local<Object> target) {
   Nan::HandleScope handle_scope;
+  v8::Local<v8::Context> context = Nan::GetCurrentContext();
 
   Local<FunctionTemplate> newTemplate = Nan::New<FunctionTemplate>(Tags::New);
   newTemplate->SetClassName(Nan::New<String>("Tags").ToLocalChecked());
@@ -17,7 +18,7 @@ void Tags::Init(Handle<Object> target) {
   Nan::SetMethod(proto, "getTags", Tags::GetTags);
 
   target->Set(Nan::New<String>("Tags").ToLocalChecked(),
-              newTemplate->GetFunction());
+              newTemplate->GetFunction(context).ToLocalChecked());
 }
 
 NODE_MODULE(ctags, Tags::Init)
@@ -34,7 +35,8 @@ tagFile* Tags::GetFile(v8::Local<v8::Object> obj) {
 
 NAN_METHOD(Tags::GetTags) {
   tagFile *tagFile = GetFile(info.This());
-  int chunkSize = info[0]->Uint32Value();
+  v8::Local<v8::Context> context = Nan::GetCurrentContext();
+  int chunkSize = info[0]->Uint32Value(context).FromJust();
   Nan::Callback *callback = new Nan::Callback(info[1].As<Function>());
   Nan::AsyncQueueWorker(new TagReader(callback, chunkSize, tagFile));
   info.GetReturnValue().SetUndefined();
@@ -44,14 +46,14 @@ NAN_METHOD(Tags::FindTags) {
   Nan::HandleScope handle_scope;
 
   tagFile *tagFile = GetFile(info.This());
-  std::string tag(*String::Utf8Value(info[0]));
+  std::string tag(*Nan::Utf8String(info[0]));
   int options = 0;
-  if (info[1]->BooleanValue())
+  if (Nan::To<bool>(info[1]).FromJust())
     options |= TAG_PARTIALMATCH;
   else
     options |= TAG_FULLMATCH;
 
-  if (info[2]->BooleanValue())
+  if (Nan::To<bool>(info[2]).FromJust())
     options |= TAG_IGNORECASE;
   else
     options |= TAG_OBSERVECASE;
@@ -61,10 +63,10 @@ NAN_METHOD(Tags::FindTags) {
   info.GetReturnValue().SetUndefined();
 }
 
-Tags::Tags(Handle<String> path) {
+Tags::Tags(Local<String> path) {
   Nan::HandleScope handle_scope;
 
-  std::string filePath(*String::Utf8Value(path));
+  std::string filePath(*Nan::Utf8String(path));
   tagFileInfo info;
   file = tagsOpen(filePath.data(), &info);
   if (!info.status.opened)

--- a/src/tags.h
+++ b/src/tags.h
@@ -9,7 +9,7 @@ using namespace v8;  // NOLINT
 
 class Tags : public node::ObjectWrap {
  public:
-  static void Init(Handle<Object> target);
+  static void Init(Local<Object> target);
 
  private:
   static NAN_METHOD(End);
@@ -20,7 +20,7 @@ class Tags : public node::ObjectWrap {
 
   static tagFile* GetFile(v8::Local<v8::Object> obj);
 
-  explicit Tags(Handle<String> path);
+  explicit Tags(Local<String> path);
   ~Tags() {
     if (file != NULL) {
       tagsClose(file);


### PR DESCRIPTION
Fixes https://github.com/atom/node-ctags/issues/16.

The following changes are included in this PR:
* Use `Nan::Utf8String` instead of `String::Utf8Value`
* Use `Nan::To` instead of `->BooleanValue`
* Use `Nan::Set` instead of `Set`
* Use `Local<Object>` instead of `Handle<Object>`
* Use `->Uint32Value(context).FromJust()` instead of `->Uint32Value()`
* Use `->GetFunction(context).ToLocalChecked()GetFunction(context).ToLocalChecked()` instead of `->GetFunction()`
* Upgrade `nan` package to the most recent `2.14.0`